### PR TITLE
Feature/fpstracker

### DIFF
--- a/src/yarppg/__init__.py
+++ b/src/yarppg/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "DigitalFilter",
     "FaceMeshDetector",
     "FilteredProcessor",
+    "FpsTracker",
     "frames_from_video",
     "get_config",
     "get_video_fps",
@@ -19,6 +20,7 @@ __all__ = [
     "Processor",
     "RegionOfInterest",
     "RoiDetector",
+    "Rppg",
     "RppgResult",
     "SelfieDetector",
     "Settings",
@@ -27,7 +29,12 @@ __all__ = [
 
 from .containers import Color, RegionOfInterest, RppgResult
 from .digital_filter import DigitalFilter
-from .helpers import bpm_from_frames_per_beat, frames_from_video, get_video_fps
+from .helpers import (
+    FpsTracker,
+    bpm_from_frames_per_beat,
+    frames_from_video,
+    get_video_fps,
+)
 from .hr_calculator import HrCalculator, PeakBasedHrCalculator
 from .processors import ChromProcessor, FilteredProcessor, Processor
 from .roi import FaceMeshDetector, RoiDetector, SelfieDetector, pixelate, pixelate_mask

--- a/src/yarppg/helpers.py
+++ b/src/yarppg/helpers.py
@@ -1,6 +1,8 @@
 """Utility functions and helpers."""
 
+import collections
 import pathlib
+import time
 import urllib.request
 from typing import Iterator
 
@@ -47,3 +49,33 @@ def get_video_fps(filename: str | pathlib.Path) -> float:
 def bpm_from_frames_per_beat(hr: ArrayLike, fps: float) -> np.ndarray:
     """Convert frames per beat to beats per minute (60 * fps / hr)."""
     return 60 * fps / np.asarray(hr)
+
+
+class FpsTracker:
+    """Utility class to track frames per second.
+
+    Use `tracker.tick()` once per update (e.g., per frame). The tracker
+    stores the time differences (dt) between successive `tick` calls.
+    You can then get the current estimate of FPS through the `tracker.fps`
+    property.
+
+    Args:
+        maxlen: number of time differences to use for FPS calculation. Defaults to 30.
+    """
+
+    def __init__(self, maxlen=30):
+        self.last_update = time.perf_counter()
+        self.dts = collections.deque(maxlen=maxlen)
+
+    def tick(self):
+        """Update tracker (call this once per loop iteration)."""
+        now = time.perf_counter()
+        self.dts.append(now - self.last_update)
+        self.last_update = now
+
+    @property
+    def fps(self) -> float:
+        """Frames per second calculated from average time difference between updates."""
+        if len(self.dts) > 0:
+            return 1 / (sum(self.dts) / len(self.dts))
+        return 1

--- a/src/yarppg/ui/qt6/simple_window.py
+++ b/src/yarppg/ui/qt6/simple_window.py
@@ -102,7 +102,7 @@ class SimpleQt6Window(QtWidgets.QMainWindow):
 
     def update_image(self, frame: np.ndarray) -> None:
         """Update image plot item with new frame."""
-        self.img_item.setImage(frame[:, ::-1])
+        self.img_item.setImage(frame)
 
     def _handle_roi(
         self, frame: np.ndarray, roi: yarppg.RegionOfInterest

--- a/src/yarppg/ui/qt6/simple_window.py
+++ b/src/yarppg/ui/qt6/simple_window.py
@@ -1,7 +1,6 @@
 """Provides a PyQt window for displaying rPPG processing in real-time."""
 
 import dataclasses
-import time
 from collections import deque
 
 import numpy as np
@@ -46,9 +45,7 @@ class SimpleQt6Window(QtWidgets.QMainWindow):
         self.history = deque(maxlen=150)
         self.setWindowTitle("yet another rPPG")
         self._init_ui()
-        self.fps = 30.0  # initial guess for FPS, will be adjusted based on actual time
-        self.dts = deque(maxlen=30)
-        self.last_update = time.perf_counter()
+        self.tracker = yarppg.FpsTracker()
         self.new_image.connect(self.update_image)
 
     def _init_ui(self) -> None:
@@ -132,16 +129,12 @@ class SimpleQt6Window(QtWidgets.QMainWindow):
     def _handle_hrvalue(self, value: float) -> None:
         """Update user interface with the new HR value."""
         if np.isfinite(value):
-            hr_bpm = self.fps * 60 / value
+            hr_bpm = self.tracker.fps * 60 / value
             self.hr_label.setText(f"HR: {hr_bpm:.1f}")
 
     def _update_fps(self):
-        now = time.perf_counter()
-        dt = now - self.last_update
-        self.dts.append(dt)
-        self.fps = 1 / np.mean(self.dts)
-        self.fps_label.setText(f"FPS: {self.fps:.1f}")
-        self.last_update = now
+        self.tracker.tick()
+        self.fps_label.setText(f"FPS: {self.tracker.fps:.1f}")
 
     def on_result(self, result: yarppg.RppgResult, frame: np.ndarray) -> None:
         """Update user interface with the new rPPG results."""

--- a/src/yarppg/ui/simplest.py
+++ b/src/yarppg/ui/simplest.py
@@ -27,6 +27,7 @@ def launch_loop(rppg: yarppg.Rppg, config: SimplestOpenCvWindowSettings) -> int:
         print(f"Could not open {config.video=!r}")
         return -1
 
+    tracker = yarppg.FpsTracker()
     while True:
         ret, frame = cam.read()
         frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
@@ -37,7 +38,9 @@ def launch_loop(rppg: yarppg.Rppg, config: SimplestOpenCvWindowSettings) -> int:
             frame, result.roi.mask != 0, alpha=config.roi_alpha
         )
         img = cv2.flip(img, 1)
-        text = f"{result.hr:.1f} (frames per beat)"
+        tracker.tick()
+        result.hr = 60 * tracker.fps / result.hr
+        text = f"{result.hr:.1f} (bpm)"
         pos = (10, img.shape[0] - 10)
         cv2.putText(img, text, pos, cv2.FONT_HERSHEY_COMPLEX, 0.8, color=FONT_COLOR)
         cv2.imshow("yarPPG", cv2.cvtColor(img, cv2.COLOR_RGB2BGR))


### PR DESCRIPTION
adding an FPS tracker utility function that can also be used in the simplest UI. Makes interpretation of HR easier (equivalent to qt6_simple) and more accurate on slower systems. (#26)

Also quickly fixes the frame mirroring issue that was accidentally introduced by fixing #24.